### PR TITLE
Updated the docker-compose.yml to include redis for ratelimiting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: "3.8"
+
+version: "3.3"
 services:
   db:
     image: postgres:12.4-alpine
@@ -36,5 +37,19 @@ services:
       - 4000:5100
     depends_on:
       - db
+
+  redis:
+    image: bitnami/redis:6.2
+    restart: always
+    environment:
+      # - ALLOW_EMPTY_PASSWORD=yes # Basically No auth. For development only
+      - REDIS_PASSWORD=password123 # If you login via the tty shell, use the command redis-cli -a $REDIS_PASSWORD to access the cli
+    ports:
+      - 6379:6379
+    volumes:
+      - redis_data:/bitnami/redis/data
+
 volumes:
   hpc_v3_db:
+  redis_data:
+


### PR DESCRIPTION
This docker-compose includes the image from bitnami. We are using the latest revision. The image also supports master nodes, replication and cluster configuration. I however ignored all those right now as I believe ops team will have a better understanding of the deployment. 

Having said that, I belive in our production, it would be great to have an elastic cache cluster so that high availability and clustering can be given to a third party provider. 

If for any reason we dont have the choice, the bitnami image will do all of that for us. 