### PR TITLE
[OPS-7901] enable build and push on Public ECR

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,49 @@
+name: HPC-API create image
+
+on:
+  push:
+    branches:
+      - dev
+    tags: ['*']
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        id: checkout
+        uses: actions/checkout@v2
+      - name: Repo Info
+        id: repo_info
+        run: |
+          export REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          echo ::set-output name=REPO_NAME::${REPO_NAME}
+      - name: Tag Info
+        id: tag_info
+        run: |
+          export IMAGE_TAG="${GITHUB_REF#refs/*/}"
+          export IMAGE_TAG=${IMAGE_TAG//[^[:alnum:].-]/-}
+          echo ::set-output name=IMAGE_TAG::$([[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]] && echo "$GITHUB_SHA" || echo "$IMAGE_TAG")
+      - name: Show image tag
+        run: |
+          echo "Image tag is ${{ steps.tag_info.outputs.IMAGE_TAG }}"
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Login to Public ECR
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+        env:
+          AWS_REGION: us-east-1
+      - name: Build, tag, and push image to Amazon ECR
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: public.ecr.aws/unocha/${{ steps.repo_info.outputs.REPO_NAME }}:${{ steps.tag_info.outputs.IMAGE_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# TODO: Amend for production 
+# TODO: Amend for production
 
-FROM unocha/nodejs:12
+FROM public.ecr.aws/unocha/nodejs:12-alpine
 
 RUN apk add -U build-base python3 py-pip
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,6 @@ services:
       - AUTHBASE_URL=http://api.hid.vm
       - WAIT_HOSTS=host.docker.internal:5432
       - WAIT_HOSTS_TIMEOUT=120
-    links:
-      - db
     depends_on:
       - db
   db:


### PR DESCRIPTION
- use ecr nodejs base image
- remove deprecated links in the docker-compose file

It would be nice if we could manage to not keep the whole build-base and python in the final image. For that we would probably need to `npm install` in the Dockerfile itself.