### PR TITLE
✨ OPS-7910: Introduce new logging system using bunyan 

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -30,6 +30,7 @@ export const CONFIG = {
   },
   logging: {
     mode: process.env.LOG_MODE,
+    path: process.env.LOG_PATH,
     color:
       process.env.LOG_COLOR === undefined
         ? undefined

--- a/config/index.ts
+++ b/config/index.ts
@@ -29,8 +29,8 @@ export const CONFIG = {
     poolIdle: 10000,
   },
   logging: {
-    mode: process.env.LOG_MODE,
-    path: process.env.LOG_PATH,
+    mode: process.env.LOG_MODE || 'live',
+    path: process.env.LOG_PATH || '/var/log/api/api.log',
     color:
       process.env.LOG_COLOR === undefined
         ? undefined

--- a/docker-compose.integrated.yml
+++ b/docker-compose.integrated.yml
@@ -15,6 +15,7 @@ services:
       - ../hpc-api-core:/srv/hpc-api-core
       - ./env/api/node.sh:/etc/services.d/node/run
     environment:
+      - LOG_MODE=devServer
       - POSTGRES_SERVER=postgres://postgres:@pgsql:5432/hpc
       - PORT=5100
       - NODE_ENV=development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - .:/srv/www
       - ./env/api/node.sh:/etc/services.d/node/run
     environment:
+      - LOG_MODE=devServer
       - POSTGRES_SERVER=postgres://demo:demo@host.docker.internal:5432/demo
       - PORT=5100
       - NODE_ENV=development

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@unocha/hpc-api-core": "^1.1.0",
     "apollo-server-hapi": "^3.5.0",
+    "bunyan": "^1.8.15",
     "class-validator": "^0.13.2",
     "graphql": "^15.7.2",
     "knex": "0.21.1",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "@hapi/hapi": "^20.2.1",
+    "@types/bunyan": "^1.8.8",
     "@types/hapi__hapi": "^20.0.9",
     "@unocha/hpc-repo-tools": "^0.3.0",
     "eslint": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check-types": "tsc --noEmit",
     "install-and-link": "sh ./bin/install.sh",
     "start": "pm2 start start.js --no-daemon",
-    "dev": "ts-node-dev --inspect=127.0.0.1:9339 --transpile-only --no-notify -- src/server.ts",
+    "dev": "ts-node-dev --inspect=127.0.0.1:9339 --transpile-only --no-notify -- start.js",
     "prepare": "husky install",
     "lint-prettier": "prettier -c .",
     "lint-eslint": "eslint --quiet .",

--- a/src/common-libs/logging/context.ts
+++ b/src/common-libs/logging/context.ts
@@ -1,0 +1,78 @@
+import bunyan from 'bunyan';
+import { format } from 'util';
+import { LogData, LogDataAfterContextProcessing } from './data';
+import merge = require('lodash/merge');
+
+import {
+  LogMethod,
+  LogContext as LogContextInterface,
+} from '@unocha/hpc-api-core/src/lib/logging';
+
+export type LogContextHandler = (
+  level: 'debug' | 'info' | 'warn' | 'error',
+  message: string,
+  opts?: {
+    data?: Partial<LogData>;
+    error?: Error;
+  }
+) => void;
+
+export class LogContext implements LogContextInterface<LogData> {
+  constructor(
+    private readonly logger: bunyan,
+    private readonly parent: LogContext | null,
+    private readonly context: Partial<LogData>,
+    private readonly listener?: LogContextHandler
+  ) {}
+
+  public extend = (
+    data: Partial<LogData>,
+    listener?: LogContextHandler
+  ): LogContext => new LogContext(this.logger, this, data, listener);
+
+  public log: LogContextHandler = (level, message, opts) => {
+    // Recursively merge context
+    const data: LogDataAfterContextProcessing = merge(
+      {},
+      this.context,
+      opts?.data || {},
+      opts?.error
+        ? {
+            stackTrace: opts.error.stack || format(opts.error),
+          }
+        : {}
+    );
+    if (this.parent) {
+      this.parent.log(level, message, { data });
+    } else {
+      this.logger[level](data, message);
+    }
+    if (this.listener) {
+      this.listener(level, message, opts);
+    }
+  };
+
+  public error: LogMethod<LogData> = (message, opts) =>
+    this.log('error', message, opts);
+
+  public warn: LogMethod<LogData> = (message, opts) =>
+    this.log('warn', message, opts);
+
+  public info: LogMethod<LogData> = (message, opts) =>
+    this.log('info', message, opts);
+
+  public debug: LogMethod<LogData> = (message, opts) =>
+    this.log('debug', message, opts);
+
+  /**
+   * Retreive a particular bit of context from either the current context or
+   * a parent's context (this is for use in more descriptive log messages)
+   */
+  public getContext = <T>(f: (data: Partial<LogData>) => T): T => {
+    const s = f(this.context);
+    if (!s && this.parent) {
+      return this.parent.getContext(f);
+    }
+    return s;
+  };
+}

--- a/src/common-libs/logging/data.ts
+++ b/src/common-libs/logging/data.ts
@@ -13,7 +13,6 @@ export interface LogData extends SharedLogData {
    */
   unhandledRejection?: {
     promise: string;
-    reason: string;
   };
 }
 

--- a/src/common-libs/logging/data.ts
+++ b/src/common-libs/logging/data.ts
@@ -1,0 +1,42 @@
+import { SharedLogData } from '@unocha/hpc-api-core/src/lib/logging';
+
+/**
+ * Structured json data that can be included along with log messages
+ * to end up in elk.
+ *
+ * We need to be very strict about the format of this data, as conflicting types
+ * will result in data being dropped by ELK. See: OPS-6862
+ */
+export interface LogData extends SharedLogData {
+  /**
+   * Set when an unhandled rejection caused the error
+   */
+  unhandledRejection?: {
+    promise: string;
+    reason: string;
+  };
+}
+
+/**
+ * A log entry's structured JSON data after being handled by the LogContext and
+ * as it's passed to bunyan
+ */
+export interface LogDataAfterContextProcessing extends LogData {
+  /**
+   * If an error has been provided,
+   * this will be its stacktrace
+   */
+  stackTrace?: string;
+}
+
+/**
+ * A log entry's structured JSON data after being handled by bunyan
+ *
+ * (this is the resulting json that is written to the log file)
+ */
+export interface LogDataAfterBunyanProcessing
+  extends LogDataAfterContextProcessing {
+  time: Date;
+  level: number;
+  msg: string;
+}

--- a/src/common-libs/logging/index.ts
+++ b/src/common-libs/logging/index.ts
@@ -63,12 +63,10 @@ export const removeLoggingListener = (l: LoggingListener) => {
 };
 
 const determineLoggingConfig = () => {
-  if (CONFIG.logging.mode) {
-    if (isLoggingMode(CONFIG.logging.mode)) {
-      return LOGGING_CONFIGS[CONFIG.logging.mode];
-    }
-    console.error('Unrecognized logging mode:', CONFIG.logging.mode);
+  if (isLoggingMode(CONFIG.logging.mode)) {
+    return LOGGING_CONFIGS[CONFIG.logging.mode];
   }
+  console.error('Unrecognized logging mode:', CONFIG.logging.mode);
   return LOGGING_CONFIGS.live;
 };
 
@@ -96,16 +94,10 @@ export const initializeLogging = (): LogContext => {
   const streams: bunyan.Stream[] = [loggingListenerStream];
 
   if (logConfig.writeToFile) {
-    if (CONFIG.logging.path) {
-      streams.push({
-        level: logConfig.writeToFile,
-        path: CONFIG.logging.path,
-      });
-    } else {
-      console.error(
-        'Unable to enable file logging as LOG_PATH is not specified'
-      );
-    }
+    streams.push({
+      level: logConfig.writeToFile,
+      path: CONFIG.logging.path,
+    });
   }
 
   if (logConfig.writeToStdout) {

--- a/src/common-libs/logging/index.ts
+++ b/src/common-libs/logging/index.ts
@@ -170,9 +170,9 @@ export const initializeLogging = async (): Promise<LogContext> => {
       data: {
         unhandledRejection: {
           promise: format(promise),
-          reason: format(reason),
         },
       },
+      ...(reason instanceof Error ? { error: reason } : {}),
     });
   });
 

--- a/src/common-libs/logging/printing.ts
+++ b/src/common-libs/logging/printing.ts
@@ -1,0 +1,57 @@
+import bunyan from 'bunyan';
+import { LogDataAfterBunyanProcessing } from './data';
+
+const printLevel = (obj: LogDataAfterBunyanProcessing, useColor: boolean) => {
+  if (obj.level >= bunyan.FATAL) {
+    return (useColor ? '\x1b[0;31;1m' : '') + '[FATAL]';
+  }
+  if (obj.level >= bunyan.ERROR) {
+    return (useColor ? '\x1b[0;31;1m' : '') + '[ERROR]';
+  }
+  if (obj.level >= bunyan.WARN) {
+    return (useColor ? '\x1b[0;33;1m' : '') + '[WARN]';
+  }
+  if (obj.level >= bunyan.INFO) {
+    return (useColor ? '\x1b[0;36;1m' : '') + '[INFO]';
+  }
+  if (obj.level >= bunyan.DEBUG) {
+    return '[DEBUG]';
+  }
+  if (obj.level >= bunyan.TRACE) {
+    return '[TRACE]';
+  }
+};
+
+export const printLog = (
+  obj: LogDataAfterBunyanProcessing,
+  useColor: boolean
+) => {
+  process.stdout.write(
+    // Make Dim
+    (useColor ? '\x1b[2m' : '') +
+      // Time
+      '[' +
+      obj.time.getHours() +
+      ':' +
+      obj.time.getMinutes() +
+      ':' +
+      obj.time.getSeconds() +
+      ':' +
+      obj.time.getMilliseconds() +
+      '] ' +
+      printLevel(obj, useColor) +
+      ' ' +
+      // Reset colors
+      (useColor ? '\x1b[0m' : '') +
+      obj.msg +
+      '\n'
+  );
+  if (obj.stackTrace) {
+    process.stdout.write(
+      obj.stackTrace
+        .split('\n')
+        .map((s) => `    ${s}`)
+        .join('\n')
+    );
+  }
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -78,4 +78,4 @@ async function startServer() {
   rootLogContext.warn(`🚀 Server ready at http://localhost:${CONFIG.httpPort}`);
 }
 
-startServer().catch((error) => console.log(error));
+startServer().catch((error) => console.error(error));

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import { CONFIG } from '../config';
 import { createDbConnetion } from './data-providers/postgres';
 import v4Models from '@unocha/hpc-api-core/src/db';
 import { getTokenFromRequest } from './common-libs/auth';
+import { initializeLogging } from './common-libs/logging';
 
 declare module '@hapi/hapi' {
   interface ServerApplicationState {
@@ -28,6 +29,8 @@ declare module '@hapi/hapi' {
      */
   }
 }
+
+initializeLogging();
 
 async function startServer() {
   const schema = await buildSchema({

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,9 +30,9 @@ declare module '@hapi/hapi' {
   }
 }
 
-const rootLogContext = initializeLogging();
-
 async function startServer() {
+  const rootLogContext = await initializeLogging();
+
   const schema = await buildSchema({
     resolvers: [join(__dirname, 'domain-services/**/resolver.{ts,js}')],
     container: Container, // Register the 3rd party IOC container

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,7 @@ declare module '@hapi/hapi' {
   }
 }
 
-initializeLogging();
+const rootLogContext = initializeLogging();
 
 async function startServer() {
   const schema = await buildSchema({
@@ -75,7 +75,7 @@ async function startServer() {
   });
 
   await hapiServer.start();
-  console.log(`🚀 Server ready at http://localhost:${CONFIG.httpPort}`);
+  rootLogContext.warn(`🚀 Server ready at http://localhost:${CONFIG.httpPort}`);
 }
 
 startServer().catch((error) => console.log(error));

--- a/yarn.lock
+++ b/yarn.lock
@@ -579,6 +579,13 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
+"@types/bunyan@^1.8.8":
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.8.tgz#8d6d33f090f37c07e2a80af30ae728450a101008"
+  integrity sha512-Cblq+Yydg3u+sGiz2mjHjC5MPmdjY+No4qvHrF+BUhblsmSfMvsHLbOG62tPbonsqBj6sbWv1LHcsoe5Jw+/Ow==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -1158,6 +1165,16 @@ buffer-writer@2.0.0:
   resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
   integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
 
+bunyan@^1.8.15:
+  version "1.8.15"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.15.tgz#8ce34ca908a17d0776576ca1b2f6cbd916e93b46"
+  integrity sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==
+  optionalDependencies:
+    dtrace-provider "~0.8"
+    moment "^2.19.3"
+    mv "~2"
+    safe-json-stringify "~1"
+
 bytes@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.1.tgz#3f018291cb4cbad9accb6e6970bca9c8889e879a"
@@ -1523,6 +1540,13 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dtrace-provider@~0.8:
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.8.tgz#2996d5490c37e1347be263b423ed7b297fb0d97e"
+  integrity sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==
+  dependencies:
+    nan "^2.14.0"
 
 dynamic-dedupe@^0.3.0:
   version "0.3.0"
@@ -2037,6 +2061,17 @@ glob-parent@^6.0.1:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.5:
   version "7.2.0"
@@ -2798,7 +2833,7 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -2823,6 +2858,13 @@ mkdirp@1.0.4, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mkdirp@~0.5.1:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+  dependencies:
+    minimist "^1.2.5"
+
 module-details-from-path@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
@@ -2835,7 +2877,7 @@ moment-timezone@^0.5.x:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0":
+"moment@>= 2.9.0", moment@^2.19.3:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
@@ -2860,6 +2902,20 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+mv@~2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
+  integrity sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=
+  dependencies:
+    mkdirp "~0.5.1"
+    ncp "~2.0.0"
+    rimraf "~2.4.0"
+
+nan@^2.14.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -2881,6 +2937,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+ncp@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 needle@2.4.0:
   version "2.4.0"
@@ -3492,6 +3553,13 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@~2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
+  integrity sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=
+  dependencies:
+    glob "^6.0.1"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -3515,6 +3583,11 @@ safe-buffer@^5.0.1, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-json-stringify@~1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
+  integrity sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==
 
 safe-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
OPS-7910

This is inspired by what we already have in hpc_service, but has a few changes / enhancements, including:

* Throwing errors when console.*() is used, including a stacktrace
  to identify where it was called from.
* A single shared LogContext used as the root for all logging
* Better module separation + initialization
* Logging JSON output file is specified using env var `LOG_PATH`