### PR TITLE
Don't enable New Relic in local development

### DIFF
--- a/docker-compose.integrated.yml
+++ b/docker-compose.integrated.yml
@@ -23,6 +23,7 @@ services:
       - POSTGRES_LOGGING=0
       - ROOT_URL=http://service.hpc.vm/
       - AUTHBASE_URL=http://api.hid.vm
+      - NEW_RELIC_LICENSE_KEY=
       - WAIT_HOSTS=pgsql:5432
       - WAIT_HOSTS_TIMEOUT=120
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - POSTGRES_LOGGING=0
       - ROOT_URL=http://service.hpc.vm/
       - AUTHBASE_URL=http://api.hid.vm
+      - NEW_RELIC_LICENSE_KEY=
       - WAIT_HOSTS=host.docker.internal:5432
       - WAIT_HOSTS_TIMEOUT=120
     links:


### PR DESCRIPTION
`NEW_RELIC_LICENSE_KEY` env variable was picking up `aaa` value from our `unocha/nodejs` Docker container parent image. That means that New Relic is loaded locally, so we get an error:
```
New Relic for Node.js halted startup due to an error:
Error: Failed to connect to collector
```
which is masked by `Unsupported use of console.error(), please use a LogContext instead`

Avoid loading New Relic locally by setting empty value for `NEW_RELIC_LICENSE_KEY` env variable.