### PR TITLE
:whale: Use `16-alpine` tag for `nodejs` image

### DIFF
--- a/env/api/Dockerfile
+++ b/env/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/unocha/nodejs:16
+FROM public.ecr.aws/unocha/nodejs:16-alpine
 
 RUN apk add -U build-base python3 py-pip
 


### PR DESCRIPTION
Using `nodejs:16` is wrong and tag `16` doesn't exist. This mistake was made in b1dd416c7e5a76e51258e9050ce3d2a02511a8f6