### PR TITLE
:package: Prepare release v4.1.0 and deploy to stage

### DIFF
--- a/docker-compose.integrated.yml
+++ b/docker-compose.integrated.yml
@@ -23,6 +23,7 @@ services:
       - POSTGRES_LOGGING=0
       - ROOT_URL=http://service.hpc.vm/
       - AUTHBASE_URL=http://api.hid.vm
+      - NEW_RELIC_LICENSE_KEY=
       - WAIT_HOSTS=pgsql:5432
       - WAIT_HOSTS_TIMEOUT=120
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - POSTGRES_LOGGING=0
       - ROOT_URL=http://service.hpc.vm/
       - AUTHBASE_URL=http://api.hid.vm
+      - NEW_RELIC_LICENSE_KEY=
       - WAIT_HOSTS=host.docker.internal:5432
       - WAIT_HOSTS_TIMEOUT=120
     links:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hpc-api",
-  "version": "0.1.0",
+  "version": "4.1.0",
   "description": "api for HPC applications",
   "main": "src/server.ts",
   "license": "MIT",


### PR DESCRIPTION
There is a bump from `v0.1.0` to `v4.1.0`, because this is v4 of API, whereas v3 is in [hpc_service](https://github.com/UN-OCHA/hpc_service) repo. Since both v3 and v4 API will coexist for some time, releases in v3 will be tagged (in Jira releases) with `api-v3.x.y`, whereas v4 releases will be tagged (in Jira releases) with `api-v4.x.y`.