### PR TITLE
Make deletedAt nullable

### DIFF
--- a/src/domain-services/base-types.ts
+++ b/src/domain-services/base-types.ts
@@ -11,6 +11,6 @@ export class BaseType {
 
 @ObjectType()
 export class BaseTypeWithSoftDelete extends BaseType {
-  @Field()
+  @Field({ nullable: true })
   deletedAt: Date;
 }


### PR DESCRIPTION
`deletedAt` can return `null` for soft delete objects if the object has not been deleted - the graphQL definitions should reflect this.