### PR TITLE
🔧 Update the credentials prompt for Sesame and use Sesame auth to download the database.

### DIFF
--- a/bin/sync-db.sh
+++ b/bin/sync-db.sh
@@ -63,6 +63,19 @@ PG_DB_NAME=$(docker exec $PG_CONTAINER printenv POSTGRES_DB)
 echo "$PG_DB_NAME"
 
 if [ $USE_LOCAL_DUMP -eq 0 ]; then
+  # Check that jq is installed
+  if ! [ -x "$(command -v jq)" ]; then
+    echo "jq NOT installed"
+    echo "Please see: https://stedolan.github.io/jq/download/"
+    exit 1
+  fi
+
+  # Check that wget is installed
+  if ! [ -x "$(command -v wget)" ]; then
+    echo "wget NOT installed. Please install wget to download latest DB dump or use -l with local dump"
+    exit 1
+  fi
+
   if [ -z "${USERNAME}" ] || [ -z "${PASSWORD}" ]; then
     echo "If not using -l flag, you must provide Sesame username and password to download the file, using -u and -p flags, respectively";
     exit 1

--- a/bin/sync-db.sh
+++ b/bin/sync-db.sh
@@ -117,6 +117,14 @@ DROP SCHEMA public CASCADE; \
   GRANT USAGE ON SCHEMA public to postgres; \
 GRANT CREATE ON SCHEMA public to postgres;" $PG_DB_NAME
 
+# Because we are using Postgre container specified elsewhere,
+# outside of docker-compose.yaml in this repo, we must manually
+# move the downloaded dumps into postgre container.
+# Ideally, local dumps directory should be mounted in PG container's `volumes`
+echo "Copy DB snapshot file to Postgre container"
+docker cp $BACKUP_DIR/$DB_DUMP $PG_CONTAINER:/backups/$DISTANT_ENV/$DB_DUMP
+docker exec -it $PG_CONTAINER ln -sf "/backups/$DISTANT_ENV/$DB_DUMP" "/backups/$DISTANT_ENV/latest.pg_restore"
+
 echo "Restore DB $DB_DUMP to $PG_DB_NAME"
 pwd
 docker exec -i $PG_CONTAINER pg_restore -v -j 4 -U postgres -O -d $PG_DB_NAME /backups/$DISTANT_ENV/$DB_DUMP

--- a/bin/sync-db.sh
+++ b/bin/sync-db.sh
@@ -48,8 +48,8 @@ while [ "$1" != "" ]; do
   shift
 done
 
-PG_CONTAINER=$(docker-compose ps | grep db | awk '{ print $1 }')
-if [[ $(docker inspect -f {{.State.Running}} $PG_CONTAINER) == 'false' ]]; then
+PG_CONTAINER=$(docker ps | grep pgsql | awk '{ print $1 }')
+if [ -z "${PG_CONTAINER}" ] || [ $(docker inspect -f {{.State.Running}} $PG_CONTAINER) == 'false' ]; then
   echo "Your Docker environment is not running. Please start it before running this script."
   exit 1
 fi

--- a/bin/sync-db.sh
+++ b/bin/sync-db.sh
@@ -102,6 +102,8 @@ if [ $USE_LOCAL_DUMP -eq 0 ]; then
   wget --header="Authorization: Bearer ${TOKEN}" https://snapshots.aws.ahconu.org/hpc-sync/$DISTANT_ENV/$DISTANT_DUMP_NAME -O "$BACKUP_DIR/$DB_DUMP" || { echo 'Copying database from source failed' ; exit 1; }
   ln -sf "$BACKUP_DIR/$DB_DUMP" "$BACKUP_DIR/latest.pg_restore"
 else
+  docker exec -it $PG_CONTAINER [ ! -e "/backups/$DISTANT_ENV/latest.pg_restore" ] && echo -e "There is no previous backup named \"latest.pg_restore\".\nPlease provide Sesame username and password to download latest $DISTANT_ENV snapshot." && exit 1
+
   echo "Using previous backup of local database"
   DB_DUMP="latest.pg_restore"
 fi

--- a/bin/sync-db.sh
+++ b/bin/sync-db.sh
@@ -63,10 +63,11 @@ PG_DB_NAME=$(docker exec $PG_CONTAINER printenv POSTGRES_DB)
 echo "$PG_DB_NAME"
 
 if [ $USE_LOCAL_DUMP -eq 0 ]; then
-  if [ "${#PASSWORD}" -eq 0 ]; then
-    echo -n "Type in your Sesame password and press enter to continue: ";
-    read -s PASSWORD;
+  if [ -z "${USERNAME}" ] || [ -z "${PASSWORD}" ]; then
+    echo "If not using -l flag, you must provide Sesame username and password to download the file, using -u and -p flags, respectively";
+    exit 1
   fi
+
   echo "Obtaining an authentication token for snapshot access"
   # `--quiet` is used to avoid wget being verbose while fetching the token, because we only need JSON response
   # `–output-document`` (-O) option is used to redirect the content to a file of our choice.


### PR DESCRIPTION
Notably, the sync script fetches a bearer token from Sesame and then uses that token to download a snapshot from the `/hpc-sync` download location. That only accepts tokens.

Refs: HPC-8381