### PR TITLE
HPC-8747: Prevent empty string version tags

### DIFF
--- a/src/common-libs/plan/versioning.ts
+++ b/src/common-libs/plan/versioning.ts
@@ -149,10 +149,17 @@ const updateBaseAndVersionModelTags = async (
   }
 
   for (const [versionTagsString, rowIds] of activeRows.entries()) {
+    const versionTags =
+      versionTagsString === '' ? [] : versionTagsString.split(',');
+
+    if (!versionTags.includes(tag.name)) {
+      versionTags.push(tag.name);
+    }
+
     await model.update({
       values: {
         latestTaggedVersion: true,
-        versionTags: [...versionTagsString.split(','), tag.name],
+        versionTags,
         ...(tag.public ? { currentVersion: true } : {}),
       },
       where: { id: { [models.Op.IN]: rowIds } },
@@ -218,15 +225,17 @@ const updateBaseAndVersionModelTags = async (
   }
 
   for (const [versionTagsString, rowIds] of versionTagsMap.entries()) {
-    const versionTags = versionTagsString.split(',');
+    const versionTags =
+      versionTagsString === '' ? [] : versionTagsString.split(',');
+
+    if (!versionTags.includes(tag.name)) {
+      versionTags.push(tag.name);
+    }
 
     await versionModel.update({
       values: {
         latestTaggedVersion: true,
-        versionTags: [
-          ...versionTags,
-          ...(versionTags.includes(tag.name) ? [] : [tag.name]),
-        ],
+        versionTags,
         ...(tag.public ? { currentVersion: true } : {}),
       },
       where: { id: { [models.Op.IN]: rowIds } },
@@ -291,7 +300,10 @@ const updateBaseModelTags = async (
       await model.update({
         values: {
           latestTaggedVersion: true,
-          versionTags: [...baseRow.versionTags, tag.name],
+          versionTags: [
+            ...baseRow.versionTags,
+            ...(baseRow.versionTags.includes(tag.name) ? [] : [tag.name]),
+          ],
           ...(tag.public ? { currentVersion: true } : {}),
         },
         where: { id: createBrandedValue(baseRow.id) },


### PR DESCRIPTION
MUST GO TOGETHER WITH https://github.com/UN-OCHA/hpc_service/pull/2856

`versionTagsString` is a key we use to group records with same version tags, in order to update them in bulk.

It is constructed with usage of `Array.prototype.join()` method, which produces an empty string when called on empty string, i.e. `[].join(',')` -> `''` That means if our record has no previous version tags, empty string will be used as a key (which is valid) to group it together with other records that don't have version tags.

Later, when we do the update, we are splitting this string key to get back version tags, but when `split()` is called on an empty string, that produces `['']`, i.e. `''.split(',')` -> `['']`. This array of one element (which is empty string) is considered as version tags array, to which we append new tag.

This is how we ended up with empty version tags.