### PR TITLE
Properly specify external network in Docker compose

### DIFF
--- a/docker-compose.integrated.yml
+++ b/docker-compose.integrated.yml
@@ -32,5 +32,5 @@ services:
           - api.hpc.vm
 networks:
   service:
-    external:
-      name: hpcservice_service
+    name: hpcservice_service
+    external: true


### PR DESCRIPTION
Pre-existing networks (defined elsewhere) are marked as `external` in `docker-compose.yml`.

Instead of using `external` as a separate-line key:
```yml
networks:
  service:
    external:
      name: hpcservice_service
```
we should define network by its name and specify its externality by using `external: true`:
```yml
networks:
  service:
    name: hpcservice_service
    external: true
```

Official docs:
https://docs.docker.com/compose/networking/#use-a-pre-existing-network

By correctly specifying `external` property, we get rid of warning "network service: network.external.name is deprecated in favor of network.name". Useful link: https://github.com/docker/compose-cli/issues/1856#issuecomment-1108552064