### PR TITLE
🚀 Release `v4.3.4` and deploy to production

### DIFF
--- a/docker-compose.integrated.yml
+++ b/docker-compose.integrated.yml
@@ -32,5 +32,5 @@ services:
           - api.hpc.vm
 networks:
   service:
-    external:
-      name: hpcservice_service
+    name: hpcservice_service
+    external: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hpc-api",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "api for HPC applications",
   "main": "src/server.ts",
   "license": "MIT",

--- a/src/common-libs/plan/versioning.ts
+++ b/src/common-libs/plan/versioning.ts
@@ -149,10 +149,17 @@ const updateBaseAndVersionModelTags = async (
   }
 
   for (const [versionTagsString, rowIds] of activeRows.entries()) {
+    const versionTags =
+      versionTagsString === '' ? [] : versionTagsString.split(',');
+
+    if (!versionTags.includes(tag.name)) {
+      versionTags.push(tag.name);
+    }
+
     await model.update({
       values: {
         latestTaggedVersion: true,
-        versionTags: [...versionTagsString.split(','), tag.name],
+        versionTags,
         ...(tag.public ? { currentVersion: true } : {}),
       },
       where: { id: { [models.Op.IN]: rowIds } },
@@ -218,15 +225,17 @@ const updateBaseAndVersionModelTags = async (
   }
 
   for (const [versionTagsString, rowIds] of versionTagsMap.entries()) {
-    const versionTags = versionTagsString.split(',');
+    const versionTags =
+      versionTagsString === '' ? [] : versionTagsString.split(',');
+
+    if (!versionTags.includes(tag.name)) {
+      versionTags.push(tag.name);
+    }
 
     await versionModel.update({
       values: {
         latestTaggedVersion: true,
-        versionTags: [
-          ...versionTags,
-          ...(versionTags.includes(tag.name) ? [] : [tag.name]),
-        ],
+        versionTags,
         ...(tag.public ? { currentVersion: true } : {}),
       },
       where: { id: { [models.Op.IN]: rowIds } },
@@ -291,7 +300,10 @@ const updateBaseModelTags = async (
       await model.update({
         values: {
           latestTaggedVersion: true,
-          versionTags: [...baseRow.versionTags, tag.name],
+          versionTags: [
+            ...baseRow.versionTags,
+            ...(baseRow.versionTags.includes(tag.name) ? [] : [tag.name]),
+          ],
           ...(tag.public ? { currentVersion: true } : {}),
         },
         where: { id: createBrandedValue(baseRow.id) },


### PR DESCRIPTION
Must be released **before** https://github.com/UN-OCHA/hpc_service/pull/2866