### PR TITLE
HPC-8672: Change how latest published reporting period is calculated

### DIFF
--- a/src/domain-services/plan-tag/plan-tag-service.ts
+++ b/src/domain-services/plan-tag/plan-tag-service.ts
@@ -60,7 +60,6 @@ export class PlanTagService {
       type: planTag.type,
       reportingPeriods: planTag.reportingPeriodIds,
     });
-    await updateLastPublishedReportingPeriodId(models, createdPlanTag);
 
     const reportingPeriodIds = Array.isArray(planTag.reportingPeriodIds)
       ? planTag.reportingPeriodIds.map(createBrandedValue)
@@ -69,6 +68,11 @@ export class PlanTagService {
       models,
       createdPlanTag,
       planTag.publishMeasurements,
+      reportingPeriodIds
+    );
+    await updateLastPublishedReportingPeriodId(
+      models,
+      createdPlanTag,
       reportingPeriodIds
     );
 


### PR DESCRIPTION
Instead of just taking the highest plan reporting period that has measurements generated, first find if any of the newly published reporting periods are higher than currently stored `lastPublishedReportingPeriodId`.

This way, we ensure that first time publishing of reporting periods using custom publishing actually updates the plan version and its `lastPublishedReportingPeriodId` field.