### PR TITLE
HPC-8663: add software info query

### DIFF
--- a/src/domain-services/software-info/graphql/resolver.ts
+++ b/src/domain-services/software-info/graphql/resolver.ts
@@ -1,0 +1,15 @@
+import SoftwareInfo from './types';
+import { Service } from 'typedi';
+import { Query, Resolver } from 'type-graphql';
+import { SoftwareInfoService } from '../software-info-service';
+
+@Service()
+@Resolver(SoftwareInfo)
+export default class SoftwareInfoResolver {
+  constructor(private softwareInfoService: SoftwareInfoService) {}
+
+  @Query(() => [SoftwareInfo])
+  softwareInfo(): SoftwareInfo[] {
+    return this.softwareInfoService.getSoftwareInfo();
+  }
+}

--- a/src/domain-services/software-info/graphql/types.ts
+++ b/src/domain-services/software-info/graphql/types.ts
@@ -1,0 +1,13 @@
+import { Field, ObjectType } from 'type-graphql';
+
+@ObjectType()
+export default class SoftwareInfo {
+  @Field({ nullable: false })
+  title: string;
+
+  @Field({ nullable: false })
+  status: string;
+
+  @Field({ nullable: false })
+  version: string;
+}

--- a/src/domain-services/software-info/software-info-service.ts
+++ b/src/domain-services/software-info/software-info-service.ts
@@ -1,0 +1,16 @@
+import { Service } from 'typedi';
+import SoftwareInfo from './graphql/types';
+import { version } from '../../../package.json';
+
+@Service()
+export class SoftwareInfoService {
+  getSoftwareInfo(): SoftwareInfo[] {
+    return [
+      {
+        title: 'HPC GraphQL API',
+        status: 'Stable',
+        version,
+      },
+    ];
+  }
+}


### PR DESCRIPTION
As described in [HPC-8663](https://humanitarian.atlassian.net/browse/HPC-8663) we needed a way to know wich version was deployed.
I've added a GraphQL resolver to query software info following this structure query
`query {
  softwareInfo {
    title
    status
    version
  }
}`

[HPC-8663]: https://humanitarian.atlassian.net/browse/HPC-8663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ