### PR TITLE
HPC-9551: Chunk model version's bulk update

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -23,6 +23,7 @@ export const CONFIG = {
   name: process.env.NODE_ENV,
   authBaseUrl: process.env.AUTHBASE_URL,
   db: {
+    batchLimit: 32_768, // 2^15,
     connection: process.env.POSTGRES_SERVER,
     logging: !!parseInt(process.env.POSTGRES_LOGGING ?? ''),
     poolMin: 2,


### PR DESCRIPTION
When publishing custom version on a plan, a bulk update is triggered on `versionModels`, including `attachmentVersion`. However, when performing a bulk update with over 100k records which is more than batch limit, it throws a "bind message has 100K+ parameter formats but 0 parameters" error. 
To address this, I'm implementing an update to `versionModels` in batches, as demonstrated practice in the following [commit](https://github.com/UN-OCHA/hpc_service/pull/3225/commits/7712c359b8816a7e4504346a6a5ca3bf23c8816d). 
Additionally, the batch limit on my local environment is `2^16`, and I assume the production environment has the same limit. However, the demo and blue dev environments have a batch limit of around `2^15`. Therefore, I'm using the lower number here.