### PR TITLE
Update Postgres images to 14.12

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -24,7 +24,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres:14.8-alpine3.18
+    image: postgres:14.12-alpine3.19
     environment:
       - POSTGRES_PASSWORD=demo
       - POSTGRES_USER=demo

--- a/tests/compose.yaml
+++ b/tests/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:14.8-alpine3.18
+    image: postgres:14.12-alpine3.19
     ports:
       - 6432:5432
     environment:


### PR DESCRIPTION
This is done to match the production version which is used on AWS RDS, according to the most recent maintenance by OPS in ticket OPS-10475.

This API depends on v3 API to start the database, thus integrated compose file is used, instead of standalone `compose.yaml` file in root of the repo. Even though this file isn't usually used, update Postgres version to keep them in sync.