### PR TITLE
HPC-8676: Adjust to breaking changes of GitHub Action

### DIFF
--- a/.github/workflow.config.json
+++ b/.github/workflow.config.json
@@ -2,19 +2,21 @@
   "stagingEnvironmentBranch": "env/stage",
   "repoType": "node",
   "developmentEnvironmentBranches": ["env/red.dev", "env/blue.dev"],
-  "docker": {
-    "path": ".",
-    "args": {
-      "commitSha": "COMMIT_SHA",
-      "treeSha": "TREE_SHA"
-    },
-    "environmentVariables": {
-      "commitSha": "HPC_ACTIONS_COMMIT_SHA",
-      "treeSha": "HPC_ACTIONS_TREE_SHA"
-    },
-    "repository": "public.ecr.aws/unocha/hpc-api",
-    "skipLogin": true
-  },
+  "dockerImages": [
+    {
+      "dockerfilePath": ".",
+      "args": {
+        "commitSha": "COMMIT_SHA",
+        "treeSha": "TREE_SHA"
+      },
+      "environmentVariables": {
+        "commitSha": "HPC_ACTIONS_COMMIT_SHA",
+        "treeSha": "HPC_ACTIONS_TREE_SHA"
+      },
+      "repository": "public.ecr.aws/unocha/hpc-api",
+      "skipLogin": true
+    }
+  ],
   "mergebackLabels": ["mergeback"],
   "deployments": {
     "environments": [


### PR DESCRIPTION
GitHub Action started supporting releasing from a monorepo, which this repository is NOT, but due to breaking changes, we need to make a couple of adjustments here:
1) Change from `docker` object to `dockerImages` array in configuration
2) Rename `path` to `dockerfilePath`