### PR TITLE
Invert Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,24 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - '@UN-OCHA/hpc-js-reviewers'
+    groups:
+      bunyan:
+        applies-to: version-updates
+        patterns:
+          - '*bunyan'
+      hapi:
+        applies-to: version-updates
+        patterns:
+          - '@hapi/hapi'
+          - '@types/hapi__hapi'
+      pg:
+        applies-to: version-updates
+        patterns:
+          - '*pg'
+      jest:
+        applies-to: version-updates
+        patterns:
+          - '*jest'
     ignore:
       # ESLint is a peer dependency of `@unocha/hpc-repo-tools`
       - dependency-name: 'eslint'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       time: '11:00'
       timezone: 'Europe/Zurich'
     open-pull-requests-limit: 10
+    versioning-strategy: increase
     reviewers:
       - '@UN-OCHA/hpc-js-reviewers'
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,24 +12,11 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - '@UN-OCHA/hpc-js-reviewers'
-    allow:
-      - dependency-name: '@unocha/hpc-api-core'
-      - dependency-name: 'bunyan'
-      - dependency-name: '@types/bunyan'
-      - dependency-name: 'class-validator'
-      - dependency-name: 'knex'
-      - dependency-name: 'pg'
-      - dependency-name: '@types/pg'
-      - dependency-name: 'pm2'
-      - dependency-name: 'reflect-metadata'
-      - dependency-name: 'ts-node'
-      - dependency-name: 'ts-node-dev'
-      - dependency-name: 'typedi'
-      - dependency-name: 'jest'
-      - dependency-name: '@types/jest'
-      - dependency-name: 'ts-jest'
-      - dependency-name: '@types/node'
-      - dependency-name: '@unocha/hpc-repo-tools'
-      - dependency-name: 'husky'
-      - dependency-name: 'lint-staged'
-      - dependency-name: 'prettier'
+    ignore:
+      # ESLint is a peer dependency of `@unocha/hpc-repo-tools`
+      - dependency-name: 'eslint'
+      # Dependency `type-graphql` still doesn't support GraphQL v16
+      - dependency-name: 'graphql'
+        versions: ['>= 16.0.0']
+      # Typescript is a peer dependency of `@unocha/hpc-repo-tools`
+      - dependency-name: 'typescript'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,11 @@ updates:
         versions: ['>= 16.0.0']
       # Typescript is a peer dependency of `@unocha/hpc-repo-tools`
       - dependency-name: 'typescript'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+      time: '11:00'
+      timezone: 'Europe/Zurich'
+    reviewers:
+      - '@UN-OCHA/hpc-js-reviewers'


### PR DESCRIPTION
Don't specify `allow` in `dependabot.yml`, because it also applies to security updates. The [`allow` configuration](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-the-dependabotyml-file) enables us to "Customize which updates are allowed", meaning if dependency isn't on the list, it isn't allowed. So, when security update attempts to update sub-dependency, which definitely isn't on the `allow` list, such update fails. Therefore, we take the inverse approach, we instead specify which dependencies **NOT** to update.