### PR TITLE
Don't upgrade Hapi version until migrating to Apollo Server 4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,11 +18,6 @@ updates:
         applies-to: version-updates
         patterns:
           - '*bunyan'
-      hapi:
-        applies-to: version-updates
-        patterns:
-          - '@hapi/hapi'
-          - '@types/hapi__hapi'
       pg:
         applies-to: version-updates
         patterns:
@@ -32,6 +27,10 @@ updates:
         patterns:
           - '*jest'
     ignore:
+      # HPC-9080: Don't upgrade Hapi version until migrating to Apollo Server 4
+      - dependency-name: '@hapi/hapi'
+        versions: ['>= 21.0.0']
+      - dependency-name: '@types/hapi__hapi'
       # ESLint is a peer dependency of `@unocha/hpc-repo-tools`
       - dependency-name: 'eslint'
       # Dependency `type-graphql` still doesn't support GraphQL v16


### PR DESCRIPTION
Package `apollo-server-hapi` that we use for Apollo Server 3 warns during installation: `"apollo-server-hapi@3.13.0" has incorrect peer dependency "@hapi/hapi@^20.1.2"` if we try to update to Hapi v21.

Even though it would likely work, don't upgrade to Hapi v21 until migrating to Apollo Server 4. When we upgrade to Hapi v21, we will also be able to remove `@types/hapi__hapi` package.