### PR TITLE
Revert batch size

### DIFF
--- a/src/domain-services/flows/flow-service.ts
+++ b/src/domain-services/flows/flow-service.ts
@@ -512,7 +512,7 @@ export class FlowService {
     const parentFlows = await this.progresiveSearch(
       models,
       parentFlowsRef,
-      PG_MAX_QUERY_PARAMS - 2, // Use a batch size of PG_MAX_QUERY_PARAMS - 2 to avoid hitting the limit
+      1000,
       0,
       false, // Do not stop on batch size
       [],


### PR DESCRIPTION
Even though using the maximum theoretical limit (defined by `PG_MAX_QUERY_PARAMS`) works, it takes a significant performance toll. The change came after [this comment](https://github.com/UN-OCHA/hpc-api/pull/352#discussion_r2098858758), in which I suggested exploring the batch size increase.

I noticed the slowness when trying to use this query:
```graphql
query {
  searchFlows(
    limit: 50
    sortField: "flow.updatedAt"
    sortOrder: "DESC"
    flowFilters: {activeStatus: true}
    flowObjectFilters: [{objectID: 4396, direction: "source", objectType: "organization"}]
    includeChildrenOfParkedFlows: true
  ) {
    total
  }
}
```
With batch size of 1000, this takes ~13 seconds and with maximum theoretical batch size it never completes (I let it for about 20 mins) and needed `shm_size: 1g` on PostgreSQL container.