### PR TITLE
HPC-10265: Search with flow versions

### DIFF
--- a/src/domain-services/external-reference/external-reference-service.ts
+++ b/src/domain-services/external-reference/external-reference-service.ts
@@ -1,6 +1,6 @@
 import { type Database } from '@unocha/hpc-api-core/src/db';
 import { type FlowId } from '@unocha/hpc-api-core/src/db/models/flow';
-import { Op } from '@unocha/hpc-api-core/src/db/util/conditions';
+import { Cond } from '@unocha/hpc-api-core/src/db/util/conditions';
 import { type InstanceDataOfModel } from '@unocha/hpc-api-core/src/db/util/raw-model';
 import { type InstanceOfModel } from '@unocha/hpc-api-core/src/db/util/types';
 import { Service } from 'typedi';
@@ -9,22 +9,30 @@ import { type SystemID } from '../report-details/graphql/types';
 
 @Service()
 export class ExternalReferenceService {
-  async getExternalReferencesForFlows(flowIDs: FlowId[], models: Database) {
+  async getExternalReferencesForFlows(
+    flowVersions: Array<{ flowID: FlowId; versionID: number }>,
+    models: Database
+  ) {
+    const externalReferencesMap = new Map<number, FlowExternalReference[]>();
+
+    if (flowVersions.length === 0) {
+      return externalReferencesMap;
+    }
+
     const externalReferences = await models.externalReference.find({
       where: {
-        flowID: {
-          [Op.IN]: flowIDs,
-        },
+        [Cond.OR]: flowVersions.map(({ flowID, versionID }) => ({
+          flowID,
+          versionID,
+        })),
       },
       skipValidation: true,
     });
 
-    const externalReferencesMap = new Map<number, FlowExternalReference[]>();
-
     // First we add all flowIDs to the map
     // Since there might be flows without external references
     // thus we want to keep them in the map
-    for (const flowID of flowIDs) {
+    for (const { flowID } of flowVersions) {
       externalReferencesMap.set(flowID, []);
     }
 

--- a/src/domain-services/flow-object/flow-object-service.ts
+++ b/src/domain-services/flow-object/flow-object-service.ts
@@ -1,7 +1,7 @@
 import { type Database } from '@unocha/hpc-api-core/src/db';
 import { type FlowId } from '@unocha/hpc-api-core/src/db/models/flow';
 import {
-  Op,
+  Cond,
   type Condition,
 } from '@unocha/hpc-api-core/src/db/util/conditions';
 import { type OrderByCond } from '@unocha/hpc-api-core/src/db/util/raw-model';
@@ -55,12 +55,20 @@ export class FlowObjectService {
     ];
   }
 
-  async getFlowObjectByFlowId(models: Database, flowIds: FlowId[]) {
+  async getFlowObjectByFlowId(
+    models: Database,
+    flowVersions: Array<{ flowID: FlowId; versionID: number }>
+  ) {
+    if (flowVersions.length === 0) {
+      return [];
+    }
+
     return await models.flowObject.find({
       where: {
-        flowID: {
-          [Op.IN]: flowIds,
-        },
+        [Cond.OR]: flowVersions.map(({ flowID, versionID }) => ({
+          flowID,
+          versionID,
+        })),
       },
     });
   }

--- a/src/domain-services/flows/flow-search-service.ts
+++ b/src/domain-services/flows/flow-search-service.ts
@@ -180,7 +180,7 @@ export class FlowSearchService {
     // Obtain external references and flow objects in parallel
     const [externalReferencesMap, flowObjects] = await Promise.all([
       this.externalReferenceService.getExternalReferencesForFlows(
-        flowIds,
+        flowVersions,
         models
       ),
       this.flowObjectService.getFlowObjectByFlowId(models, flowVersions),

--- a/src/domain-services/flows/flow-search-service.ts
+++ b/src/domain-services/flows/flow-search-service.ts
@@ -173,13 +173,17 @@ export class FlowSearchService {
       flowVersionIDs.push(flow.versionID);
     }
 
+    const flowVersions = [...flowWithVersion].flatMap(([flowID, versionIDs]) =>
+      versionIDs.map((versionID) => ({ flowID, versionID }))
+    );
+
     // Obtain external references and flow objects in parallel
     const [externalReferencesMap, flowObjects] = await Promise.all([
       this.externalReferenceService.getExternalReferencesForFlows(
         flowIds,
         models
       ),
-      this.flowObjectService.getFlowObjectByFlowId(models, flowIds),
+      this.flowObjectService.getFlowObjectByFlowId(models, flowVersions),
     ]);
 
     // Map flow objects to their respective arrays

--- a/src/domain-services/flows/flow-search-service.ts
+++ b/src/domain-services/flows/flow-search-service.ts
@@ -223,7 +223,7 @@ export class FlowSearchService {
       this.locationService.getLocationsForFlows(locationsFO, models),
       this.planService.getPlansForFlows(plansFO, models),
       this.usageYearService.getUsageYearsForFlows(usageYearsFO, models),
-      this.reportDetailService.getReportDetailsForFlows(flowIds, models),
+      this.reportDetailService.getReportDetailsForFlows(flowVersions, models),
     ]);
 
     const promises = flows.map(async (flow) => {

--- a/src/domain-services/flows/flow-service.ts
+++ b/src/domain-services/flows/flow-service.ts
@@ -398,7 +398,7 @@ export class FlowService {
       },
     });
 
-    const parentFlows: number[] = [];
+    const parentFlowIds: FlowId[] = [];
 
     for (const flowLinkParentID of flowLinksParentsIDs) {
       const parkedParentCategoryRef = await models.categoryRef.find({
@@ -411,17 +411,17 @@ export class FlowService {
       });
 
       if (parkedParentCategoryRef && parkedParentCategoryRef.length > 0) {
-        parentFlows.push(flowLinkParentID);
+        parentFlowIds.push(flowLinkParentID);
       }
     }
 
     const parkedParentFlowObjectsOrganizationSource: FlowObject[] = [];
 
-    for (const parentFlow of parentFlows) {
+    for (const parentFlowId of parentFlowIds) {
       const parkedParentOrganizationFlowObject =
         await models.flowObject.findOne({
           where: {
-            flowID: createBrandedValue(parentFlow),
+            flowID: parentFlowId,
             objectType: 'organization',
             refDirection: 'source',
             versionID: flow.versionID,

--- a/src/domain-services/flows/flow-service.ts
+++ b/src/domain-services/flows/flow-service.ts
@@ -386,7 +386,7 @@ export class FlowService {
         (flowLink) =>
           flowLink.parentID !== flow.id && flowLink.childID === flow.id
       )
-      .map((flowLink) => flowLink.parentID.valueOf());
+      .map((flowLink) => flowLink.parentID);
 
     if (flowLinksParentsIDs.length === 0) {
       return null;

--- a/src/domain-services/flows/flow-service.ts
+++ b/src/domain-services/flows/flow-service.ts
@@ -2,7 +2,10 @@ import { type Database } from '@unocha/hpc-api-core/src/db';
 import { type FlowId } from '@unocha/hpc-api-core/src/db/models/flow';
 import { Op } from '@unocha/hpc-api-core/src/db/util/conditions';
 import { type InstanceOfModel } from '@unocha/hpc-api-core/src/db/util/types';
-import { splitIntoChunks } from '@unocha/hpc-api-core/src/util';
+import {
+  organizeObjectsByUniqueProperty,
+  splitIntoChunks,
+} from '@unocha/hpc-api-core/src/util';
 import { PG_MAX_QUERY_PARAMS } from '@unocha/hpc-api-core/src/util/consts';
 import {
   createBrandedValue,
@@ -398,13 +401,31 @@ export class FlowService {
       },
     });
 
+    const parentFlowsByLatestVersion = organizeObjectsByUniqueProperty(
+      await models.flow.find({
+        where: {
+          id: { [Op.IN]: flowLinksParentsIDs },
+          activeStatus: true,
+        },
+      }),
+      'id'
+    );
+
     const parentFlowIds: FlowId[] = [];
 
     for (const flowLinkParentID of flowLinksParentsIDs) {
+      const flowLinkParent = parentFlowsByLatestVersion.get(flowLinkParentID);
+
+      if (!flowLinkParent) {
+        throw new Error(
+          `Cannot find latest version of flow with ID ${flowLinkParentID}`
+        );
+      }
+
       const parkedParentCategoryRef = await models.categoryRef.find({
         where: {
           categoryID: parkedCategory?.id,
-          versionID: flow.versionID,
+          versionID: flowLinkParent.versionID,
           objectID: flowLinkParentID,
           objectType: 'flow',
         },

--- a/src/domain-services/flows/flow-service.ts
+++ b/src/domain-services/flows/flow-service.ts
@@ -411,7 +411,7 @@ export class FlowService {
       'id'
     );
 
-    const parentFlowIds: FlowId[] = [];
+    const parentFlowVersions: Array<{ flowID: FlowId; versionID: number }> = [];
 
     for (const flowLinkParentID of flowLinksParentsIDs) {
       const flowLinkParent = parentFlowsByLatestVersion.get(flowLinkParentID);
@@ -432,20 +432,23 @@ export class FlowService {
       });
 
       if (parkedParentCategoryRef && parkedParentCategoryRef.length > 0) {
-        parentFlowIds.push(flowLinkParentID);
+        parentFlowVersions.push({
+          flowID: flowLinkParentID,
+          versionID: flowLinkParent.versionID,
+        });
       }
     }
 
     const parkedParentFlowObjectsOrganizationSource: FlowObject[] = [];
 
-    for (const parentFlowId of parentFlowIds) {
+    for (const { flowID, versionID } of parentFlowVersions) {
       const parkedParentOrganizationFlowObject =
         await models.flowObject.findOne({
           where: {
-            flowID: parentFlowId,
+            flowID,
             objectType: 'organization',
             refDirection: 'source',
-            versionID: flow.versionID,
+            versionID,
           },
         });
 

--- a/src/domain-services/report-details/report-detail-service.ts
+++ b/src/domain-services/report-details/report-detail-service.ts
@@ -1,6 +1,6 @@
 import { type Database } from '@unocha/hpc-api-core/src/db';
 import { type FlowId } from '@unocha/hpc-api-core/src/db/models/flow';
-import { Op } from '@unocha/hpc-api-core/src/db/util/conditions';
+import { Cond } from '@unocha/hpc-api-core/src/db/util/conditions';
 import { type InstanceDataOfModel } from '@unocha/hpc-api-core/src/db/util/raw-model';
 import { type InstanceOfModel } from '@unocha/hpc-api-core/src/db/util/types';
 import { getOrCreate } from '@unocha/hpc-api-core/src/util';
@@ -11,34 +11,38 @@ import { type ReportDetail } from './graphql/types';
 @Service()
 export class ReportDetailService {
   async getReportDetailsForFlows(
-    flowIds: FlowId[],
+    flowVersions: Array<{ flowID: FlowId; versionID: number }>,
     models: Database
   ): Promise<Map<number, ReportDetail[]>> {
-    const reportDetails: Array<InstanceDataOfModel<Database['reportDetail']>> =
-      await models.reportDetail.find({
-        where: {
-          flowID: {
-            [Op.IN]: flowIds,
-          },
-        },
-        skipValidation: true,
-      });
-
     const reportDetailsMap = new Map<number, ReportDetail[]>();
 
-    for (const flowId of flowIds) {
-      if (!reportDetailsMap.has(flowId)) {
-        reportDetailsMap.set(flowId, []);
+    if (flowVersions.length === 0) {
+      return reportDetailsMap;
+    }
+
+    const reportDetails = await models.reportDetail.find({
+      where: {
+        [Cond.OR]: flowVersions.map(({ flowID, versionID }) => ({
+          flowID,
+          versionID,
+        })),
+      },
+      skipValidation: true,
+    });
+
+    for (const { flowID } of flowVersions) {
+      if (!reportDetailsMap.has(flowID)) {
+        reportDetailsMap.set(flowID, []);
       }
 
       const flowsReportingDetails = reportDetails.filter(
-        (report) => report.flowID === flowId
+        (report) => report.flowID === flowID
       );
 
       if (flowsReportingDetails && flowsReportingDetails.length > 0) {
         const reportDetailsPerFlow = getOrCreate(
           reportDetailsMap,
-          flowId,
+          flowID,
           () => []
         );
 


### PR DESCRIPTION
The main problem that is behind this PR is described in Jira ticket:
> Filter flows by IDs 144645, 182780 to see that Source organizations are displayed differently. The reason is that GraphQL API returns nothing in `parkedParentSource` for the first flow and instead puts parked parent’s source organization in `organization` array

It was determined that we're not doing search by parent flow's version and instead we were using child flow's version. Similar type of problem was found in other parts of the codebase, where version was not even used in searches.